### PR TITLE
update syntax for obsevables in MSSM and MRSSM2 model files

### DIFF
--- a/model_files/MRSSM2/FlexibleSUSY.m.in
+++ b/model_files/MRSSM2/FlexibleSUSY.m.in
@@ -93,7 +93,9 @@ ExtraSLHAOutputBlocks = {
          {23, FlexibleSUSYObservable`EDM[Fe[1]]},
          {24, FlexibleSUSYObservable`EDM[Fe[2]]},
          {25, FlexibleSUSYObservable`EDM[Fe[3]]},
-         {26, FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[1], VP}]}
+         {26, FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[1], VP}]},
+         {31, FlexibleSUSYObservable`BrLTo3L[Fe[2] -> {Fe[1], Fe[1], SARAH`bar[Fe[1]]}, All, 1]},
+         {41, FlexibleSUSYObservable`LToLConversion[Fe[2] -> Fe[1], Al, All, 1]}
       }
    }
 };

--- a/model_files/MSSM/FlexibleSUSY.m.in
+++ b/model_files/MSSM/FlexibleSUSY.m.in
@@ -143,7 +143,9 @@ ExtraSLHAOutputBlocks = {
             {23, FlexibleSUSYObservable`EDM[Fe[1]]},
             {24, FlexibleSUSYObservable`EDM[Fe[2]]},
             {25, FlexibleSUSYObservable`EDM[Fe[3]]},
-            {26, FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[1], VP}]}
+            {26, FlexibleSUSYObservable`BrLToLGamma[Fe[2] -> {Fe[1], VP}]},
+            {31, FlexibleSUSYObservable`BrLTo3L[Fe[2] -> {Fe[1], Fe[1], SARAH`bar[Fe[1]]}, All, 1]},
+            {41, FlexibleSUSYObservable`LToLConversion[Fe[2] -> Fe[1], Al, All, 1]}
            }
    }
 };


### PR DESCRIPTION
Maybe I've messed something up but I think that line as
```wolfram
{40, FlexibleSUSYObservable`LToLConversion[Fe[2] -> Fe[1], Au, All, 1]}
```
doesn't work.